### PR TITLE
FPET-1120-CI build issue fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,3 @@ jobs:
           cache: 'gradle'
       - name: Build
         run: ./gradlew check
-      - name: Dependency check
-        run: ./gradlew dependencyCheckAggregate

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ def versions = [
   gradlePitest                 : '1.15.0',
   pitest                       : '1.16.1',
   sonarPitest                  : '0.5',
+  s2sClient                    : '4.0.3',
 ]
 
 
@@ -438,8 +439,10 @@ dependencies {
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: '3.0.0'
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
   implementation group: 'io.springfox', name: 'springfox-spring-webflux', version: '3.0.0'
-  implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
-  implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
+  //implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.s2sClient
+  //implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
+  implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
   implementation group: 'com.azure', name: 'azure-core', version: '1.48.0'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.0'


### PR DESCRIPTION
JIRA link (if applicable)
[FPET-1120](https://tools.hmcts.net/jira/browse/FPET-1120)

Change description
CI build issue fix
and removed the dependencyCheck step from ci.yml file since it was failing due to no NVD key

The dependencyCheckAggregate is already implemented as a part of Jenkins Pipeline and this removal is also there to make the repo ci.yml consistent with the PRL repos like (prl-cos,prl-dgs)