### PR TITLE
FPVTL-1268: Remove outdated and invalid launch darkly tag

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/hmc/api/services/HearingsDataServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/api/services/HearingsDataServiceImpl.java
@@ -189,13 +189,9 @@ public class HearingsDataServiceImpl implements HearingsDataService {
                                         : null)
                         .hearingChannels(Arrays.asList())
                         .build();
-        if (launchDarklyClient.isFeatureEnabled("hearing-case-flags-v2")) {
-            log.info("Case flags V2 flag is enabled");
-            caseFlagV2DataService.setCaseFlagsV2Data(serviceHearingValues, caseDetails);
-        } else {
-            log.info("Case flags V2 flag is disabled");
-            caseFlagV2DataService.setCaseFlagData(serviceHearingValues, caseDetails);
-        }
+
+        caseFlagV2DataService.setCaseFlagsV2Data(serviceHearingValues, caseDetails);
+
         return serviceHearingValues;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/hmc/api/services/HearingsDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/api/services/HearingsDataServiceTest.java
@@ -160,7 +160,6 @@ class HearingsDataServiceTest {
         when(authTokenGenerator.generate()).thenReturn("MOCK_S2S_TOKEN");
         when(caseApiService.getCaseDetails(anyString(), anyString(), anyString()))
                 .thenReturn(caseDetails);
-        when(launchDarklyClient.isFeatureEnabled("hearing-case-flags-v2")).thenReturn(false);
 
         String authorisation = "xyz";
         String serviceAuthorisation = "xyz";
@@ -172,7 +171,6 @@ class HearingsDataServiceTest {
         Assertions.assertEquals("ABA5", hearingsResponse.getHmctsServiceID());
         Assertions.assertEquals("Re-Minor", hearingsResponse.getPublicCaseName());
         Assertions.assertNotNull(hearingsResponse.getCaseDeepLink());
-        verify(caseFlagV2DataService, times(2)).setCaseFlagData(any(), any());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-1268

### Change description ###

Remove outdated and invalid launch darkly toggle. AAT is already using Case Flags V2 successfully.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
